### PR TITLE
refactor: features mutability in reduction signature and AsInner

### DIFF
--- a/reductionml-cli/src/train.rs
+++ b/reductionml-cli/src/train.rs
@@ -403,7 +403,7 @@ impl Command for TrainCommand {
 fn process_example(
     label: Option<Label>,
     workspace: &mut reductionml_core::workspace::Workspace,
-    features: Features<'_>,
+    mut features: Features<'_>,
     predictions_file: &mut Option<io::BufWriter<File>>,
     metrics: &mut Vec<Box<dyn Metric>>,
     manager: &mut TrainResultManager,
@@ -413,7 +413,7 @@ fn process_example(
     >,
 ) {
     let label = label.unwrap();
-    let prediction = workspace.predict_then_learn(&features, &label);
+    let prediction = workspace.predict_then_learn(&mut features, &label);
     if let Some(file) = predictions_file.as_mut() {
         writeln!(file, "{}", serde_json::to_string(&prediction).unwrap()).unwrap();
     }

--- a/reductionml-core/src/metrics/ips.rs
+++ b/reductionml-core/src/metrics/ips.rs
@@ -1,4 +1,4 @@
-use crate::{metrics::Metric, utils::GetInner, ActionProbsPrediction, CBLabel, Features};
+use crate::{metrics::Metric, utils::AsInner, ActionProbsPrediction, CBLabel, Features};
 
 use super::MetricValue;
 
@@ -29,8 +29,8 @@ impl Metric for IpsMetric {
         label: &crate::types::Label,
         prediction: &crate::types::Prediction,
     ) {
-        let label: &CBLabel = label.get_inner_ref().unwrap();
-        let pred: &ActionProbsPrediction = prediction.get_inner_ref().unwrap();
+        let label: &CBLabel = label.as_inner().unwrap();
+        let pred: &ActionProbsPrediction = prediction.as_inner().unwrap();
 
         let p_log = label.probability;
         let p_pred = pred

--- a/reductionml-core/src/metrics/mean_squared_error.rs
+++ b/reductionml-core/src/metrics/mean_squared_error.rs
@@ -1,4 +1,4 @@
-use crate::{metrics::Metric, utils::GetInner, Features, ScalarPrediction, SimpleLabel};
+use crate::{metrics::Metric, utils::AsInner, Features, ScalarPrediction, SimpleLabel};
 
 use super::MetricValue;
 
@@ -29,8 +29,8 @@ impl Metric for MeanSquaredErrorMetric {
         label: &crate::types::Label,
         prediction: &crate::types::Prediction,
     ) {
-        let label: &SimpleLabel = label.get_inner_ref().unwrap();
-        let pred: &ScalarPrediction = prediction.get_inner_ref().unwrap();
+        let label: &SimpleLabel = label.as_inner().unwrap();
+        let pred: &ScalarPrediction = prediction.as_inner().unwrap();
         self.value += (label.0 - pred.prediction) * (label.0 - pred.prediction);
         self.count += 1;
     }

--- a/reductionml-core/src/parsers/dsjson_parser.rs
+++ b/reductionml-core/src/parsers/dsjson_parser.rs
@@ -234,7 +234,7 @@ mod test {
         object_pool::Pool,
         parsers::{DsJsonParserFactory, TextModeParser, TextModeParserFactory},
         sparse_namespaced_features::Namespace,
-        utils::GetInner,
+        utils::AsInner,
         CBAdfFeatures, CBLabel, FeaturesType, LabelType,
     };
     #[test]
@@ -294,12 +294,12 @@ mod test {
         );
 
         let (features, label) = parser.parse_chunk(&json_obj.to_string()).unwrap();
-        let cb_label: &CBLabel = label.as_ref().unwrap().get_inner_ref().unwrap();
+        let cb_label: &CBLabel = label.as_ref().unwrap().as_inner().unwrap();
         assert_eq!(cb_label.action, 3);
         assert_relative_eq!(cb_label.cost, 0.0);
         assert_relative_eq!(cb_label.probability, 0.05);
 
-        let cb_feats: &CBAdfFeatures = features.get_inner_ref().unwrap();
+        let cb_feats: &CBAdfFeatures = features.as_inner().unwrap();
         assert_eq!(cb_feats.actions.len(), 1);
         assert!(cb_feats.shared.is_some());
         let shared = cb_feats.shared.as_ref().unwrap();

--- a/reductionml-core/src/parsers/text_parser.rs
+++ b/reductionml-core/src/parsers/text_parser.rs
@@ -33,5 +33,7 @@ pub trait TextModeParser: Sync {
     fn extract_feature_names<'a>(
         &self,
         chunk: &'a str,
-    ) -> Result<std::collections::HashMap<ParsedNamespaceInfo<'a>, Vec<ParsedFeature<'a>>>>;
+    ) -> Result<std::collections::HashMap<ParsedNamespaceInfo<'a>, Vec<ParsedFeature<'a>>>> {
+        todo!()
+    }
 }

--- a/reductionml-core/src/parsers/vw_text_parser.rs
+++ b/reductionml-core/src/parsers/vw_text_parser.rs
@@ -10,7 +10,7 @@ use crate::object_pool::Pool;
 use crate::parsers::ParsedFeature;
 use crate::sparse_namespaced_features::{Namespace, SparseFeatures};
 use crate::types::{Features, Label, LabelType};
-use crate::utils::GetInner;
+use crate::utils::AsInner;
 use crate::{CBAdfFeatures, CBLabel, FeatureMask, FeaturesType, SimpleLabel};
 
 use super::{ParsedNamespaceInfo, TextModeParser, TextModeParserFactory};
@@ -29,8 +29,14 @@ enum TextLabel {
     CB(CBTextLabel),
 }
 
-impl GetInner<CBTextLabel> for TextLabel {
-    fn get_inner_ref(&self) -> Option<&CBTextLabel> {
+impl AsInner<CBTextLabel> for TextLabel {
+    fn as_inner(&self) -> Option<&CBTextLabel> {
+        match self {
+            TextLabel::CB(f) => Some(f),
+            _ => None,
+        }
+    }
+    fn as_inner_mut(&mut self) -> Option<&mut CBTextLabel> {
         match self {
             TextLabel::CB(f) => Some(f),
             _ => None,
@@ -77,7 +83,7 @@ where
             let first_label: &CBTextLabel = txt_labels_iter
                 .peek()
                 .ok_or(Error::InvalidArgument("".to_owned()))?
-                .get_inner_ref()
+                .as_inner()
                 .expect("Label should be CB");
             let first_is_shared = first_label.shared;
 
@@ -93,7 +99,7 @@ where
             // Find the labelled action.
             let mut label: Option<CBLabel> = None;
             for (counter, action_label) in txt_labels_iter.enumerate() {
-                let lbl: &CBTextLabel = action_label.get_inner_ref().expect("Label should be CB");
+                let lbl: &CBTextLabel = action_label.as_inner().expect("Label should be CB");
                 if let Some((_a, c, p)) = lbl.acp {
                     if label.is_some() {
                         return Err(Error::InvalidArgument(

--- a/reductionml-core/src/reductions/binary.rs
+++ b/reductionml-core/src/reductions/binary.rs
@@ -6,7 +6,7 @@ use crate::reduction::{
 use crate::reduction_factory::{
     create_reduction, JsonReductionConfig, PascalCaseString, ReductionConfig, ReductionFactory,
 };
-use crate::utils::GetInner;
+use crate::utils::AsInner;
 
 use crate::reductions::CoinRegressorConfig;
 use crate::{impl_default_factory_functions, types::*, ModelIndex};
@@ -103,24 +103,24 @@ impl From<BinaryLabel> for SimpleLabel {
 impl ReductionImpl for BinaryReduction {
     fn predict(
         &self,
-        features: &Features,
+        features: &mut Features,
         depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) -> Prediction {
         let pred = self.regressor.predict(features, depth_info, 0.into());
-        let scalar_pred: &ScalarPrediction = pred.get_inner_ref().unwrap();
+        let scalar_pred: &ScalarPrediction = pred.as_inner().unwrap();
 
         Prediction::Binary((scalar_pred.prediction > 0.0).into())
     }
 
     fn predict_then_learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) -> Prediction {
-        let binary_label: &BinaryLabel = label.get_inner_ref().unwrap();
+        let binary_label: &BinaryLabel = label.as_inner().unwrap();
 
         let pred = self.regressor.predict_then_learn(
             features,
@@ -129,19 +129,19 @@ impl ReductionImpl for BinaryReduction {
             0.into(),
         );
 
-        let scalar_pred: &ScalarPrediction = pred.get_inner_ref().unwrap();
+        let scalar_pred: &ScalarPrediction = pred.as_inner().unwrap();
 
         Prediction::Binary((scalar_pred.prediction > 0.0).into())
     }
 
     fn learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) {
-        let binary_label: &BinaryLabel = label.get_inner_ref().unwrap();
+        let binary_label: &BinaryLabel = label.as_inner().unwrap();
 
         self.regressor.learn(
             features,

--- a/reductionml-core/src/reductions/cb_explore_adf_greedy.rs
+++ b/reductionml-core/src/reductions/cb_explore_adf_greedy.rs
@@ -153,7 +153,7 @@ impl CBExploreAdfGreedyReduction {
 impl ReductionImpl for CBExploreAdfGreedyReduction {
     fn predict(
         &self,
-        features: &Features,
+        features: &mut Features,
         depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) -> Prediction {
@@ -164,7 +164,7 @@ impl ReductionImpl for CBExploreAdfGreedyReduction {
 
     fn learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,

--- a/reductionml-core/src/reductions/coin.rs
+++ b/reductionml-core/src/reductions/coin.rs
@@ -282,7 +282,7 @@ impl ReductionImpl for CoinRegressor {
             score += (1.0 / uncertain) * feat_value.signum();
         };
 
-        let feat = features.get_inner_ref().unwrap();
+        let feat = features.as_inner().unwrap();
         foreach_feature_with_state(
             ModelIndex::from(0),
             feat,

--- a/reductionml-core/src/reductions/coin.rs
+++ b/reductionml-core/src/reductions/coin.rs
@@ -12,7 +12,7 @@ use crate::reduction::{
 use crate::reduction_factory::{PascalCaseString, ReductionConfig, ReductionFactory};
 use crate::sparse_namespaced_features::{Namespace, SparseFeatures};
 use crate::utils::bits_to_max_feature_index;
-use crate::utils::GetInner;
+use crate::utils::AsInner;
 use crate::weights::{foreach_feature, foreach_feature_with_state, foreach_feature_with_state_mut};
 use crate::{impl_default_factory_functions, types::*, ModelIndex, StateIndex};
 use schemars::schema::RootSchema;
@@ -184,11 +184,11 @@ impl ReductionFactory for CoinRegressorFactory {
 impl ReductionImpl for CoinRegressor {
     fn predict(
         &self,
-        features: &Features,
+        features: &mut Features,
         _depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) -> Prediction {
-        let sparse_feats: &SparseFeatures = features.get_inner_ref().unwrap();
+        let sparse_feats: &SparseFeatures = features.as_inner().unwrap();
 
         let mut prediction = 0.0;
         foreach_feature(
@@ -215,13 +215,13 @@ impl ReductionImpl for CoinRegressor {
 
     fn predict_then_learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         _depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) -> Prediction {
-        let sparse_feats: &SparseFeatures = features.get_inner_ref().unwrap();
-        let simple_label: &SimpleLabel = label.get_inner_ref().unwrap();
+        let sparse_feats: &SparseFeatures = features.as_inner().unwrap();
+        let simple_label: &SimpleLabel = label.as_inner().unwrap();
 
         self.min_label = simple_label.0.min(self.min_label);
         self.max_label = simple_label.0.max(self.max_label);
@@ -241,13 +241,13 @@ impl ReductionImpl for CoinRegressor {
 
     fn learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         _depth_info: &mut DepthInfo,
         _model_offset: ModelIndex,
     ) {
-        let sparse_feats: &SparseFeatures = features.get_inner_ref().unwrap();
-        let simple_label: &SimpleLabel = label.get_inner_ref().unwrap();
+        let sparse_feats: &SparseFeatures = features.as_inner().unwrap();
+        let simple_label: &SimpleLabel = label.as_inner().unwrap();
 
         self.min_label = simple_label.0.min(self.min_label);
         self.max_label = simple_label.0.max(self.max_label);
@@ -456,10 +456,10 @@ mod tests {
         let ns = features.get_or_create_namespace(Namespace::Default);
         ns.add_feature(0.into(), 1.0);
 
-        let features = Features::SparseSimple(features);
+        let mut features = Features::SparseSimple(features);
 
         let mut depth_info = DepthInfo::new();
-        let prediction = coin.predict(&features, &mut depth_info, 0.into());
+        let prediction = coin.predict(&mut features, &mut depth_info, 0.into());
         // Ensure the prediction is of variant Scalar
         assert!(matches!(prediction, Prediction::Scalar { .. }));
     }
@@ -482,36 +482,36 @@ mod tests {
         }
 
         let mut depth_info = DepthInfo::new();
-        let features = Features::SparseSimple(features);
+        let mut features = Features::SparseSimple(features);
         coin.learn(
-            &features,
+            &mut features,
             &Label::Simple(SimpleLabel(0.5, 1.0)),
             &mut depth_info,
             0.into(),
         );
         coin.learn(
-            &features,
+            &mut features,
             &Label::Simple(SimpleLabel(0.5, 1.0)),
             &mut depth_info,
             0.into(),
         );
         coin.learn(
-            &features,
+            &mut features,
             &Label::Simple(SimpleLabel(0.5, 1.0)),
             &mut depth_info,
             0.into(),
         );
         coin.learn(
-            &features,
+            &mut features,
             &Label::Simple(SimpleLabel(0.5, 1.0)),
             &mut depth_info,
             0.into(),
         );
 
-        let pred = coin.predict(&features, &mut depth_info, 0.into());
+        let pred = coin.predict(&mut features, &mut depth_info, 0.into());
 
         assert!(matches!(pred, Prediction::Scalar { .. }));
-        let pred1: &ScalarPrediction = pred.get_inner_ref().unwrap();
+        let pred1: &ScalarPrediction = pred.as_inner().unwrap();
         assert_relative_eq!(pred1.prediction, 0.5);
     }
 
@@ -532,9 +532,9 @@ mod tests {
             }
 
             let mut depth_info = DepthInfo::new();
-            let features = Features::SparseSimple(features);
+            let mut features = Features::SparseSimple(features);
             regressor.learn(
-                &features,
+                &mut features,
                 &Label::Simple(SimpleLabel(yhat(_x), 1.0)),
                 &mut depth_info,
                 0.into(),
@@ -549,11 +549,11 @@ mod tests {
             }
 
             let mut depth_info = DepthInfo::new();
-            let features = Features::SparseSimple(features);
-            let pred = regressor.predict(&features, &mut depth_info, 0.into());
+            let mut features = Features::SparseSimple(features);
+            let pred = regressor.predict(&mut features, &mut depth_info, 0.into());
             assert!(matches!(pred, Prediction::Scalar { .. }));
 
-            let pred_value: &ScalarPrediction = pred.get_inner_ref().unwrap();
+            let pred_value: &ScalarPrediction = pred.as_inner().unwrap();
             assert_relative_eq!(pred_value.prediction, yhat(x), epsilon = 0.1);
         }
     }

--- a/reductionml-core/src/reductions/debug.rs
+++ b/reductionml-core/src/reductions/debug.rs
@@ -144,7 +144,7 @@ impl DebugReduction {
 impl ReductionImpl for DebugReduction {
     fn predict(
         &self,
-        features: &Features,
+        features: &mut Features,
         depth_info: &mut DepthInfo,
         model_offset: ModelIndex,
     ) -> Prediction {
@@ -171,7 +171,7 @@ impl ReductionImpl for DebugReduction {
 
     fn predict_then_learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         depth_info: &mut DepthInfo,
         model_offset: ModelIndex,
@@ -210,7 +210,7 @@ impl ReductionImpl for DebugReduction {
 
     fn learn(
         &mut self,
-        features: &Features,
+        features: &mut Features,
         label: &Label,
         depth_info: &mut DepthInfo,
         model_offset: ModelIndex,

--- a/reductionml-core/src/sparse_namespaced_features.rs
+++ b/reductionml-core/src/sparse_namespaced_features.rs
@@ -1,9 +1,10 @@
-use std::io::Cursor;
+use std::{collections::BTreeSet, io::Cursor};
 
 use crate::{
     hash::FNV_PRIME, object_pool::PoolReturnable, utils::bits_to_max_feature_index, FeatureHash,
     FeatureIndex, FeatureMask, NamespaceHash,
 };
+use approx::AbsDiffEq;
 use itertools::Itertools;
 use murmur3::murmur3_32;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,7 @@ pub struct NamespaceIterator<'a> {
     values: std::slice::Iter<'a, f32>,
 }
 
+// TODO this should be skipping inactive namespaces.
 impl<'a> Iterator for NamespacesIterator<'a> {
     type Item = (Namespace, NamespaceIterator<'a>);
     fn next(&mut self) -> Option<Self::Item> {
@@ -50,7 +52,28 @@ pub struct SparseFeaturesNamespace {
     namespace: Namespace,
     feature_indices: Vec<FeatureIndex>,
     feature_values: Vec<f32>,
+    /// active is an optimization for usage solely in the SparseFeatures struct
+    /// it is used to avoid iterating over the namespace when it is not active
+    /// and also allow for object reuse
     active: bool,
+}
+
+impl AbsDiffEq for SparseFeaturesNamespace {
+    type Epsilon = f32;
+
+    fn default_epsilon() -> Self::Epsilon {
+        core::f32::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        self.namespace == other.namespace
+            && self.feature_indices == other.feature_indices
+            && self
+                .feature_values
+                .iter()
+                .zip(other.feature_values.iter())
+                .all(|(a, b)| a.abs_diff_eq(b, epsilon))
+    }
 }
 
 impl SparseFeaturesNamespace {
@@ -129,7 +152,7 @@ impl SparseFeaturesNamespace {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Serialize, Deserialize, PartialOrd, Ord, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Namespace {
     Named(NamespaceHash),
     Default,
@@ -168,11 +191,49 @@ impl Default for SparseFeatures {
     }
 }
 
+impl AbsDiffEq for SparseFeatures {
+    type Epsilon = f32;
+
+    fn default_epsilon() -> Self::Epsilon {
+        core::f32::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        let left_ns: BTreeSet<Namespace> = self
+            .namespaces
+            .iter()
+            .filter_map(|(ns, ns_vals)| if ns_vals.is_active() { Some(ns) } else { None })
+            .cloned()
+            .collect();
+
+        let right_ns = other
+            .namespaces
+            .iter()
+            .filter_map(|(ns, ns_vals)| if ns_vals.is_active() { Some(ns) } else { None })
+            .cloned()
+            .collect();
+        if left_ns != right_ns {
+            return false;
+        }
+
+        for ns in left_ns {
+            let ns_vals = self.namespaces.get(&ns).unwrap();
+            let other_ns_vals = other.namespaces.get(&ns).unwrap();
+            if !ns_vals.abs_diff_eq(other_ns_vals, epsilon) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+// Essentially Fowler–Noll–Vo hash function
 fn quadratic_feature_hash(i1: FeatureIndex, i2: FeatureIndex) -> FeatureHash {
     let multiplied = (FNV_PRIME as u64).wrapping_mul(u32::from(i1) as u64) as u32;
     (multiplied ^ u32::from(i2)).into()
 }
 
+// Essentially Fowler–Noll–Vo hash function
 fn cubic_feature_hash(i1: FeatureIndex, i2: FeatureIndex, i3: FeatureIndex) -> FeatureHash {
     let multiplied = (FNV_PRIME as u64).wrapping_mul(u32::from(i1) as u64) as u32;
     let multiplied = (FNV_PRIME as u64).wrapping_mul((multiplied ^ u32::from(i2)) as u64) as u32;

--- a/reductionml-core/src/types.rs
+++ b/reductionml-core/src/types.rs
@@ -1,7 +1,8 @@
+use approx::AbsDiffEq;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    object_pool::PoolReturnable, sparse_namespaced_features::SparseFeatures, utils::GetInner,
+    object_pool::PoolReturnable, sparse_namespaced_features::SparseFeatures, utils::AsInner,
 };
 use derive_more::TryInto;
 use std::ops::Deref;
@@ -13,8 +14,14 @@ macro_rules! impl_conversion_traits {
             }
         }
 
-        impl GetInner<$structname> for $target_type {
-            fn get_inner_ref(&self) -> Option<&$structname> {
+        impl AsInner<$structname> for $target_type {
+            fn as_inner(&self) -> Option<&$structname> {
+                match self {
+                    $target_type::$enum_variant(f) => Some(f),
+                    _ => None,
+                }
+            }
+            fn as_inner_mut(&mut self) -> Option<&mut $structname> {
                 match self {
                     $target_type::$enum_variant(f) => Some(f),
                     _ => None,
@@ -122,6 +129,36 @@ pub struct CBAdfFeatures {
     pub actions: Vec<SparseFeatures>,
 }
 
+impl AbsDiffEq for CBAdfFeatures {
+    type Epsilon = f32;
+
+    fn default_epsilon() -> Self::Epsilon {
+        core::f32::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if let (Some(shared), Some(other_shared)) = (&self.shared, &other.shared) {
+            if !shared.abs_diff_eq(other_shared, epsilon) {
+                return false;
+            }
+        } else if let (None, None) = (&self.shared, &other.shared) {
+            // ok
+        } else {
+            return false;
+        }
+
+        if self.actions.len() != other.actions.len() {
+            return false;
+        }
+        for (a, b) in self.actions.iter().zip(other.actions.iter()) {
+            if !a.abs_diff_eq(b, epsilon) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 impl PoolReturnable<SparseFeatures> for CBAdfFeatures {
     fn clear_and_return_object(self, pool: &crate::object_pool::Pool<SparseFeatures>) {
         if let Some(shared) = self.shared {
@@ -147,14 +184,22 @@ macro_rules! impl_conversion_traits_feats {
         //     }
         // }
 
-        impl<'a> From<&'a $structname> for Features<'a> {
-            fn from(f: &'a $structname) -> Features<'a> {
+        impl<'a> From<&'a mut $structname> for Features<'a> {
+            fn from(f: &'a mut $structname) -> Features<'a> {
                 Features::$enum_variant_ref(f)
             }
         }
 
-        impl GetInner<$structname> for Features<'_> {
-            fn get_inner_ref(&self) -> Option<&$structname> {
+        impl AsInner<$structname> for Features<'_> {
+            fn as_inner(&self) -> Option<&$structname> {
+                match self {
+                    Features::$enum_variant(f) => Some(f),
+                    Features::$enum_variant_ref(f) => Some(f),
+                    _ => None,
+                }
+            }
+
+            fn as_inner_mut(&mut self) -> Option<&mut $structname> {
                 match self {
                     Features::$enum_variant(f) => Some(f),
                     Features::$enum_variant_ref(f) => Some(f),
@@ -165,12 +210,53 @@ macro_rules! impl_conversion_traits_feats {
     };
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Debug)]
 pub enum Features<'a> {
     SparseSimple(SparseFeatures),
-    SparseSimpleRef(&'a SparseFeatures),
+    SparseSimpleRef(&'a mut SparseFeatures),
     SparseCBAdf(CBAdfFeatures),
-    SparseCBAdfRef(&'a CBAdfFeatures),
+    SparseCBAdfRef(&'a mut CBAdfFeatures),
+}
+
+impl<'a> Features<'a> {
+    pub fn clone(&self) -> Features<'static> {
+        match self {
+            Features::SparseSimple(f) => Features::SparseSimple(f.clone()),
+            Features::SparseSimpleRef(f) => Features::SparseSimple((*f).clone()),
+            Features::SparseCBAdf(f) => Features::SparseCBAdf(f.clone()),
+            Features::SparseCBAdfRef(f) => Features::SparseCBAdf((*f).clone()),
+        }
+    }
+}
+
+impl<'a> AbsDiffEq for Features<'a> {
+    type Epsilon = f32;
+
+    fn default_epsilon() -> Self::Epsilon {
+        core::f32::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        match (self, other) {
+            (
+                Features::SparseSimple(_) | Features::SparseSimpleRef(_),
+                Features::SparseSimple(_) | Features::SparseSimpleRef(_),
+            ) => {
+                let left: &SparseFeatures = self.as_inner().unwrap();
+                let right: &SparseFeatures = other.as_inner().unwrap();
+                left.abs_diff_eq(right, epsilon)
+            }
+            (
+                Features::SparseCBAdf(_) | Features::SparseCBAdfRef(_),
+                Features::SparseCBAdf(_) | Features::SparseCBAdfRef(_),
+            ) => {
+                let left: &CBAdfFeatures = self.as_inner().unwrap();
+                let right: &CBAdfFeatures = other.as_inner().unwrap();
+                left.abs_diff_eq(right, epsilon)
+            }
+            (_, _) => false,
+        }
+    }
 }
 
 // impl_conversion_traits!(Features, SparseSimple, SparseFeatures);
@@ -294,7 +380,7 @@ impl FeatureMask {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, Debug)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash, Deserialize, Serialize, Debug)]
 pub struct NamespaceHash(u32);
 impl_extra_traits!(NamespaceHash, u32);
 

--- a/reductionml-core/src/utils.rs
+++ b/reductionml-core/src/utils.rs
@@ -5,6 +5,7 @@ pub fn bits_to_max_feature_index(val: u8) -> FeatureIndex {
     FeatureIndex::from(1_u32 << (val as u32))
 }
 
-pub trait GetInner<T>: Sized {
-    fn get_inner_ref(&self) -> Option<&T>;
+pub trait AsInner<T>: Sized {
+    fn as_inner(&self) -> Option<&T>;
+    fn as_inner_mut(&mut self) -> Option<&mut T>;
 }

--- a/reductionml-core/src/workspace.rs
+++ b/reductionml-core/src/workspace.rs
@@ -157,19 +157,19 @@ impl Workspace {
             .map_err(|e| Error::InvalidConfiguration(format!("Failed to parse model: {e}")))
     }
 
-    pub fn predict(&self, features: &Features) -> Prediction {
+    pub fn predict(&self, features: &mut Features) -> Prediction {
         let mut depth_info = DepthInfo::new();
         self.entry_reduction
             .predict(features, &mut depth_info, 0.into())
     }
 
-    pub fn predict_then_learn(&mut self, features: &Features, label: &Label) -> Prediction {
+    pub fn predict_then_learn(&mut self, features: &mut Features, label: &Label) -> Prediction {
         let mut depth_info = DepthInfo::new();
         self.entry_reduction
             .predict_then_learn(features, label, &mut depth_info, 0.into())
     }
 
-    pub fn learn(&mut self, features: &Features, label: &Label) {
+    pub fn learn(&mut self, features: &mut Features, label: &Label) {
         let mut depth_info = DepthInfo::new();
         self.entry_reduction
             .learn(features, label, &mut depth_info, 0.into());
@@ -194,7 +194,7 @@ mod tests {
     use approx::assert_relative_eq;
     use serde_json::json;
 
-    use crate::{sparse_namespaced_features::SparseFeatures, utils::GetInner, ScalarPrediction};
+    use crate::{sparse_namespaced_features::SparseFeatures, utils::AsInner, ScalarPrediction};
 
     use super::*;
 
@@ -223,20 +223,20 @@ mod tests {
         ns.add_feature(2.into(), 1.0);
         ns.add_feature(3.into(), 1.0);
 
-        let features = Features::SparseSimple(features);
+        let mut features = Features::SparseSimple(features);
 
-        let pred = workspace.predict(&features);
-        let scalar_pred: &ScalarPrediction = pred.get_inner_ref().unwrap();
+        let pred = workspace.predict(&mut features);
+        let scalar_pred: &ScalarPrediction = pred.as_inner().unwrap();
         assert_relative_eq!(scalar_pred.prediction, 0.0);
 
         let label = Label::Simple(0.5.into());
 
         // For some reason two calls to learn are required to get a non-zero prediction for coin?
-        workspace.learn(&features, &label);
-        workspace.learn(&features, &label);
+        workspace.learn(&mut features, &label);
+        workspace.learn(&mut features, &label);
 
-        let pred = workspace.predict(&features);
-        let scalar_pred: &ScalarPrediction = pred.get_inner_ref().unwrap();
+        let pred = workspace.predict(&mut features);
+        let scalar_pred: &ScalarPrediction = pred.as_inner().unwrap();
         assert_relative_eq!(scalar_pred.prediction, 0.5);
     }
 }


### PR DESCRIPTION
- Make features mutable down stack for optimizations. It became clear that the benefits of an immutable features object did not outweigh the cost.
- Rename GetInner to AsInner to better reflect semantics and add mut function
- Make features float diff comparable
- Add debug checks for reductions restoring state correctly