### PR TITLE
perf: specify thin LTO in workspace cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "reductionml-core",
     "reductionml-cli",
 ]
+
+[profile.release]
+lto = "thin"


### PR DESCRIPTION
This had a large performance improvement when I tested it while not being as expensive as fat LTO